### PR TITLE
Update naming.php

### DIFF
--- a/src/Rules/naming.php
+++ b/src/Rules/naming.php
@@ -31,7 +31,7 @@ because('it\'s a Laravel naming convention', function () {
 because('it\'s a Laravel naming convention', function () {
     return Rule::allClasses()
         ->that(new ResideInOneOfTheseNamespaces('App\*\Repositories'))
-        ->should(new HaveNameMatching('*Repository'));
+        ->should(new HaveNameMatching('*Impl'));
 });
 
 because('it\'s a Laravel naming convention', function () {


### PR DESCRIPTION
Change naming convention for the Repositories to '*impl' because the last convention we agreed upon was that the contract would be named '*Repository' and the repository '*impl'